### PR TITLE
Update to finch 0.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ organization := "io.github.benwhitehead.finch"
 
 name := "finch-server"
 
-version := "0.5.0"
+version := "0.6.0-SNAPSHOT"
 
-scalaVersion := "2.10.3"
+crossScalaVersions := Seq("2.10.3", "2.11.4")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation")
 
@@ -14,19 +14,18 @@ javacOptions in doc := Seq("-source", "1.7")
 
 resolvers += "Twitter" at "http://maven.twttr.com/"
 
-resolvers += "Finch.io" at "http://repo.konfettin.ru"
-
 libraryDependencies ++= Seq(
-  "io"              %% "finch"              % "0.1.6",
-  "com.twitter"     %% "finagle-stats"      % "6.22.0",
-  "com.twitter"     %% "finagle-core"       % "6.22.0",
-  "com.twitter"     %% "twitter-server"     % "1.8.0",
-  "org.slf4j"       %  "slf4j-api"          % "1.7.7",
-  "org.slf4j"       %  "jul-to-slf4j"       % "1.7.7",
-  "org.slf4j"       %  "jcl-over-slf4j"     % "1.7.7",
-  "org.slf4j"       %  "log4j-over-slf4j"   % "1.7.7",
-  "ch.qos.logback"  %  "logback-classic"    % "1.1.2"   % "test",
-  "org.scalatest"   %% "scalatest"          % "2.2.2"   % "test"
+  "com.github.finagle"  %% "finch-core"         % "0.3.0",
+  "com.github.finagle"  %% "finch-json"         % "0.3.0",
+  "com.twitter"         %% "finagle-stats"      % "6.24.0",
+  "com.twitter"         %% "finagle-httpx"      % "6.24.0",
+  "com.twitter"         %% "twitter-server"     % "1.9.0",
+  "org.slf4j"           %  "slf4j-api"          % "1.7.10",
+  "org.slf4j"           %  "jul-to-slf4j"       % "1.7.10",
+  "org.slf4j"           %  "jcl-over-slf4j"     % "1.7.10",
+  "org.slf4j"           %  "log4j-over-slf4j"   % "1.7.10",
+  "ch.qos.logback"      %  "logback-classic"    % "1.1.2"   % "test",
+  "org.scalatest"       %% "scalatest"          % "2.2.2"   % "test"
 )
 
 parallelExecution in Test := false

--- a/src/main/scala/io/github/benwhitehead/finch/Flags.scala
+++ b/src/main/scala/io/github/benwhitehead/finch/Flags.scala
@@ -2,12 +2,12 @@ package io.github.benwhitehead.finch
 
 import com.twitter.app.GlobalFlag
 
-object adminHttpPort extends GlobalFlag[Int](9990, "the TCP port for the admin http server")
 object httpPort extends GlobalFlag[Int](7070, "the TCP port for the http server")
 object pidFile extends GlobalFlag[String]("", "The file to write the pid of the process into")
 object httpsPort extends GlobalFlag[Int](7443, "the TCP port for the https server")
 object certificatePath extends GlobalFlag[String]("", "Path to PEM format SSL certificate file")
 object keyPath extends GlobalFlag[String]("", "Path to SSL Key file")
 object maxRequestSize extends GlobalFlag[Int](5, "Max request size (in megabytes)")
-object decompressionEnabled extends GlobalFlag[Boolean](false, "Enables deflate,gzip Content-Encoding handling")
-object compressionLevel extends GlobalFlag[Int](6, "Enables deflate,gzip Content-Encoding handling")
+// TODO: Figure out how to add back compression support
+//object decompressionEnabled extends GlobalFlag[Boolean](false, "Enables deflate,gzip Content-Encoding handling")
+//object compressionLevel extends GlobalFlag[Int](6, "Enables deflate,gzip Content-Encoding handling")

--- a/src/main/scala/io/github/benwhitehead/finch/JacksonWrapper.scala
+++ b/src/main/scala/io/github/benwhitehead/finch/JacksonWrapper.scala
@@ -19,6 +19,7 @@ package io.github.benwhitehead.finch
 import com.fasterxml.jackson.core.`type`.TypeReference
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import io.finch.json.{DecodeJson, EncodeJson}
 import java.io.{InputStream, Reader, StringWriter}
 import java.lang.reflect.{ParameterizedType, Type}
 
@@ -57,4 +58,12 @@ object JacksonWrapper {
       def getOwnerType = null
     }
   }
+}
+
+class JacksonJsonEncoder[-A] extends EncodeJson[A] {
+  override def apply(json: A): String = JacksonWrapper.serialize(json)
+}
+
+class JacksonJsonDecoder[+A] extends DecodeJson[A] {
+  override def apply(json: String): Option[A] = JacksonWrapper.deserialize(json)
 }

--- a/src/main/scala/io/github/benwhitehead/finch/package.scala
+++ b/src/main/scala/io/github/benwhitehead/finch/package.scala
@@ -16,11 +16,10 @@
 package io.github.benwhitehead
 
 import com.twitter.finagle.Service
-import com.twitter.finagle.http.{Response, Status}
+import com.twitter.finagle.httpx.{Response, Status}
 import com.twitter.util.Future
 import io.finch._
-import io.finch.response.{BadRequest, Respond}
-import org.jboss.netty.handler.codec.http.HttpResponseStatus
+import io.finch.response.BadRequest
 
 package object finch {
 
@@ -48,10 +47,6 @@ package object finch {
     BadRequest.withHeaders("Accept" -> "application/json; charset=utf-8")()
   )
 
-  object Accepted extends Respond(Status.Accepted)
-  object BadGateway extends Respond(Status.BadGateway)
-  object ServiceUnavailable extends Respond(Status.ServiceUnavailable)
-
   // this is a class rather than an object so that it can be type
   // parametrized
   case class OptionResponse[T]() extends Service[Option[T], T] {
@@ -65,7 +60,7 @@ package object finch {
 
   object JacksonResponseSerializer extends Service[Any, HttpResponse] {
     override def apply(request: Any): Future[HttpResponse] = {
-      val rep = Response(HttpResponseStatus.OK)
+      val rep = com.twitter.finagle.httpx.Response(Status.Ok)
       rep.setContentTypeJson()
       rep.setContentString(JacksonWrapper.serialize(request))
       rep.toFuture

--- a/src/main/scala/io/github/benwhitehead/finch/request/package.scala
+++ b/src/main/scala/io/github/benwhitehead/finch/request/package.scala
@@ -4,9 +4,6 @@ import com.twitter.finagle.Service
 import com.twitter.util.Future
 import io.finch._
 import io.finch.request.RequestReader
-import org.jboss.netty.util.CharsetUtil
-
-import scala.util.parsing.json.{JSONArray, JSON, JSONObject}
 
 package object request {
 
@@ -29,104 +26,4 @@ package object request {
     }
   }
 
-  object RequiredStringBody {
-    def apply() = new RequestReader[String] {
-      def apply(req: HttpRequest): Future[String] = {
-        req.contentLength match {
-          case Some(length) if length > 0 => req.content.toString(CharsetUtil.UTF_8).toFuture
-          case _                          => new BadRequest().toFutureException
-        }
-      }
-    }
-  }
-
-  /**
-   * Use Jackson to attempt to deserialize Request Body into a `T`
-   */
-  object RequiredJsonBody {
-    def apply[T: Manifest]() = new RequestReader[T] {
-      def apply(req: HttpRequest): Future[T] = {
-        req.headerMap.get("Content-Type") match {
-          case Some("application/json; charset=utf-8") =>
-            JacksonWrapper.deserialize[T](req.content.toString(CharsetUtil.UTF_8)).toFuture
-          case _ => new AcceptJsonOnlyException().toFutureException
-        }
-      }
-    }
-  }
-
-  object RequiredJSONObjectBody {
-    def apply() = new RequestReader[JSONObject] {
-      def apply(req: HttpRequest): Future[JSONObject] = {
-        req.headerMap.get("Content-Type") match {
-          case Some("application/json; charset=utf-8") =>
-            JSON.parseRaw(req.content.toString(CharsetUtil.UTF_8)) match {
-              case Some(obj: JSONObject) => obj.toFuture
-              case Some(arr: JSONArray) => new AcceptJsonOnlyException().toFutureException
-              case None => new AcceptJsonOnlyException().toFutureException
-            }
-          case _ => new AcceptJsonOnlyException().toFutureException
-        }
-      }
-    }
-  }
-
-  object RequiredJSONArrayBody {
-    def apply() = new RequestReader[JSONArray] {
-      def apply(req: HttpRequest): Future[JSONArray] = {
-        req.headerMap.get("Content-Type") match {
-          case Some("application/json; charset=utf-8") =>
-            JSON.parseRaw(req.content.toString(CharsetUtil.UTF_8)) match {
-              case Some(obj: JSONObject) => new AcceptJsonOnlyException().toFutureException
-              case Some(arr: JSONArray) => arr.toFuture
-              case None => new AcceptJsonOnlyException().toFutureException
-            }
-          case _ => new AcceptJsonOnlyException().toFutureException
-        }
-      }
-    }
-  }
-
-  object OptionalStringBody {
-    def apply() = new RequestReader[Option[String]] {
-      def apply(req: HttpRequest): Future[Option[String]] = {
-        req.contentLength match {
-          case Some(length) if length > 0 => Some(req.content.toString(CharsetUtil.UTF_8)).toFuture
-          case _                          => None.toFuture
-        }
-      }
-    }
-  }
-
-  object OptionalJSONObjectBody {
-    def apply() = new RequestReader[Option[JSONObject]] {
-      def apply(req: HttpRequest): Future[Option[JSONObject]] = {
-        req.headerMap.get("Content-Type") match {
-          case Some("application/json; charset=utf-8") =>
-            JSON.parseRaw(req.content.toString(CharsetUtil.UTF_8)) match {
-              case Some(obj: JSONObject) => Some(obj).toFuture
-              case Some(arr: JSONArray) => None.toFuture
-              case None => None.toFuture
-            }
-          case _ => None.toFuture
-        }
-      }
-    }
-  }
-
-  object OptionalJSONArrayBody {
-    def apply() = new RequestReader[Option[JSONArray]] {
-      def apply(req: HttpRequest): Future[Option[JSONArray]] = {
-        req.headerMap.get("Content-Type") match {
-          case Some("application/json; charset=utf-8") =>
-            JSON.parseRaw(req.content.toString(CharsetUtil.UTF_8)) match {
-              case Some(obj: JSONObject) => None.toFuture
-              case Some(arr: JSONArray) => Some(arr).toFuture
-              case None => None.toFuture
-            }
-          case _ => None.toFuture
-        }
-      }
-    }
-  }
 }

--- a/src/test/scala/io/github/benwhitehead/finch/FlagsTest.scala
+++ b/src/test/scala/io/github/benwhitehead/finch/FlagsTest.scala
@@ -16,6 +16,7 @@
 package io.github.benwhitehead.finch
 
 import java.io.{ByteArrayOutputStream, PrintStream}
+import java.net.InetSocketAddress
 import java.security.Permission
 
 import io.finch.Endpoint
@@ -48,19 +49,19 @@ class FlagsTest extends FreeSpec with BeforeAndAfterEach {
       server.main(Array())
       val config = server.config
       assert(config.port === 7070)
-      assert(config.adminPort === 9990)
+      assert(server.adminPort() === new InetSocketAddress(9990))
       assert(config.pidPath === "")
     }
 
     "set" in {
       server.main(Array(
         "-io.github.benwhitehead.finch.httpPort=1234",
-        "-io.github.benwhitehead.finch.adminHttpPort=4321",
+        "-admin.port=:4321",
         "-io.github.benwhitehead.finch.pidFile=/tmp/server.pid"
       ))
       val config = server.config
       assert(config.port === 1234)
-      assert(config.adminPort === 4321)
+      assert(server.adminPort() === new InetSocketAddress(4321))
       assert(config.pidPath === "/tmp/server.pid")
     }
 
@@ -75,7 +76,7 @@ class FlagsTest extends FreeSpec with BeforeAndAfterEach {
         case e: SecurityException =>
           assert(e.getMessage === "System.exit(1) trapped")
           val string = baos.toString
-          assert(string.contains("-io.github.benwhitehead.finch.adminHttpPort"))
+          assert(string.contains("-admin.port"))
           assert(string.contains("-io.github.benwhitehead.finch.httpPort"))
           assert(string.contains("-io.github.benwhitehead.finch.pidFile"))
       } finally {

--- a/src/test/scala/io/github/benwhitehead/finch/TestingServer.scala
+++ b/src/test/scala/io/github/benwhitehead/finch/TestingServer.scala
@@ -1,12 +1,13 @@
 package io.github.benwhitehead.finch
 
 import com.twitter.finagle.Service
-import com.twitter.finagle.http.Method
-import com.twitter.finagle.http.path.{->, /, Root}
+import com.twitter.finagle.httpx.Method
+import com.twitter.finagle.httpx.path.{->, /, Root}
 import com.twitter.util.Future
 import io.finch._
+import io.finch.request.RequiredStringBody
 import io.finch.response._
-import io.github.benwhitehead.finch.request.{RequiredStringBody, DelegateService}
+import io.github.benwhitehead.finch.request.DelegateService
 
 /**
  * @author Ben Whitehead
@@ -34,7 +35,7 @@ object JsonBlob extends HttpEndpoint {
 
   lazy val handlePost = new Service[HttpRequest, HttpResponse] {
     lazy val reader = for {
-      body <- RequiredStringBody()
+      body <- RequiredStringBody
     } yield body
 
     def apply(request: HttpRequest): Future[HttpResponse] = {
@@ -45,13 +46,14 @@ object JsonBlob extends HttpEndpoint {
     }
   }
   def route = {
-    case Method.Get -> Root / "json" => service
+    case Method.Get  -> Root / "json" => service
     case Method.Post -> Root / "json" => handlePost
   }
 }
 
 object TestingServer extends SimpleFinchServer {
-  override lazy val config = Config(port = 17070, adminPort = 19990, decompressionEnabled = true, compressionLevel = 6)
+  override lazy val defaultHttpPort = 19990
+  override lazy val config = Config(port = 17070)
   override lazy val serverName = "test-server"
   def endpoint = {
     Echo orElse JsonBlob


### PR DESCRIPTION
Update following libraries:
- finch -> finch-core 0.3.0
- finagle-http -> finagle-httpx 6.24.0
- finagle-stats -> finagle-stats 6.24.0
- slf4j-\* -> slf4j-\* 1.7.10

All code updated to be inline with new versions of `finch-core` and `finagle-httpx`.

Noteworthy changes:
- Removed all Body readers as they are now provided by `finch-core`
- FinchServer
  - The admin server is now bootstrapped by `AdminHttpServer` rather than being bootstrapped manually.
  - Configuration of the admin server port is now down with the flag `admin.port`
  - The function `getCodec` no longer exists since it is not longer applicable now that Httpx is the server builder.
  - The functions `startServer` and `startTlsServer` now return `ListeningServer` to be inline with the Httpx server builder.
- sbt config updated to allow cross compilation for scala 2.11
- version incremented to `0.6.0-SNAPSHOT`

Regression:
- [ ] Due to the new Httpx server builder response compression is no longer possible.
