### PR TITLE
Add flag to enable/disable access logging rather than relying on log level filtering alone.

### DIFF
--- a/src/main/resources/example-logback.xml
+++ b/src/main/resources/example-logback.xml
@@ -49,9 +49,6 @@
   <logger name="access-log" level="trace">
     <appender-ref ref="access-log"/>
   </logger>
-  <logger name="access-log-combined" level="OFF">
-    <appender-ref ref="access-log"/>
-  </logger>
 
   <root level="debug">
     <appender-ref ref="STDOUT"/>

--- a/src/main/scala/io/github/benwhitehead/finch/FinchServer.scala
+++ b/src/main/scala/io/github/benwhitehead/finch/FinchServer.scala
@@ -134,8 +134,7 @@ trait FinchServer[Request] extends App
   }
 
   def getService(serviceName: String): Service[HttpRequest, HttpResponse] = {
-    new StatsFilter(serviceName) !
-      AccessLog !
+    AccessLog(new StatsFilter(serviceName), accessLog()) !
       errorHandler(serviceName) !
       filter !
       (endpoint orElse NotFound(serviceName))

--- a/src/main/scala/io/github/benwhitehead/finch/Flags.scala
+++ b/src/main/scala/io/github/benwhitehead/finch/Flags.scala
@@ -11,3 +11,4 @@ object maxRequestSize extends GlobalFlag[Int](5, "Max request size (in megabytes
 // TODO: Figure out how to add back compression support
 //object decompressionEnabled extends GlobalFlag[Boolean](false, "Enables deflate,gzip Content-Encoding handling")
 //object compressionLevel extends GlobalFlag[Int](6, "Enables deflate,gzip Content-Encoding handling")
+object accessLog extends GlobalFlag[String]("access-log", "Whether to add an Access Log Filter, and if so which type [off|access-log{default}|access-log-combined]. Any value other than the listed 3 will be treated as off.")

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -20,7 +20,6 @@
   </appender>
 
   <logger name="access-log" level="trace"/>
-  <logger name="access-log-combined" level="OFF"/>
 
   <root level="debug">
     <appender-ref ref="STDOUT"/>


### PR DESCRIPTION
Access logging is now all written to the 'access-log' category and the content written depends on the value of the flag.

Fixes #5 
