### PR TITLE
Update server interface/port configuration to be done via flags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ The motivation behind using flags is that when running applications on Mesos or 
 ```
 -admin.port=:9990                                         : the TCP port for the admin http server
 -io.github.benwhitehead.finch.certificatePath=            : Path to PEM format SSL certificate file
--io.github.benwhitehead.finch.httpPort=7070               : the TCP port for the http server
--io.github.benwhitehead.finch.httpsPort=7443              : the TCP port for the https server
+-io.github.benwhitehead.finch.httpInterface=:7070         : The TCP Interface and port for the http server {[<hostname/ip>]:port}. (Set to empty value to disable)
+-io.github.benwhitehead.finch.httpsInterface=             : The TCP Interface and port for the https server {[<hostname/ip>]:port}. Requires -io.github.benwhitehead.finch.certificatePath and -io.github.benwhitehead.finch.keyPath to be set. (Set to empty value to disable)
 -io.github.benwhitehead.finch.keyPath=                    : Path to SSL Key file
 -io.github.benwhitehead.finch.maxRequestSize=5            : Max request size (in megabytes)
 -io.github.benwhitehead.finch.pidFile=                    : The file to write the pid of the process into
@@ -48,6 +48,7 @@ finch-server is very easy to use, all you need to create an echo server is the f
 ### Server Object
 ```scala
 import io.finch._
+import io.github.benwhitehead.finch.FinchServer
 
 object EchoServer extends FinchServer {
   override lazy val serverName = "echo"

--- a/src/main/scala/io/github/benwhitehead/finch/Flags.scala
+++ b/src/main/scala/io/github/benwhitehead/finch/Flags.scala
@@ -1,11 +1,38 @@
 package io.github.benwhitehead.finch
 
-import com.twitter.app.GlobalFlag
+import java.net.InetSocketAddress
 
-object httpPort extends GlobalFlag[Int](7070, "the TCP port for the http server")
+import com.twitter.app.{Flaggable, GlobalFlag}
+
+private[finch] object Flaggables {
+  implicit def flagOfOption[T](implicit flaggable: Flaggable[T]) = new Flaggable[Option[T]] {
+    override def parse(s: String): Option[T] = {
+      Option(s)
+        .map(_.trim)
+        .collect {
+          case x if x.nonEmpty => x
+        }
+        .map(flaggable.parse)
+    }
+
+    override def show(t: Option[T]): String = t match {
+      case Some(tt) => flaggable.show(tt)
+      case None => ""
+    }
+  }
+}
+
 object pidFile extends GlobalFlag[String]("", "The file to write the pid of the process into")
-object httpsPort extends GlobalFlag[Int](7443, "the TCP port for the https server")
 object certificatePath extends GlobalFlag[String]("", "Path to PEM format SSL certificate file")
 object keyPath extends GlobalFlag[String]("", "Path to SSL Key file")
 object maxRequestSize extends GlobalFlag[Int](5, "Max request size (in megabytes)")
 object accessLog extends GlobalFlag[String]("access-log", "Whether to add an Access Log Filter, and if so which type [off|access-log{default}|access-log-combined]. Any value other than the listed 3 will be treated as off.")
+
+object httpInterface extends GlobalFlag[Option[InetSocketAddress]](
+  Some(new InetSocketAddress("0.0.0.0", 7070)),
+  s"The TCP Interface and port for the http server {[<hostname/ip>]:port}. (Set to empty value to disable)"
+)(Flaggables.flagOfOption)
+object httpsInterface extends GlobalFlag[Option[InetSocketAddress]](
+  None,
+  s"The TCP Interface and port for the https server {[<hostname/ip>]:port}. Requires -${certificatePath.name} and -${keyPath.name} to be set. (Set to empty value to disable)"
+)(Flaggables.flagOfOption)

--- a/src/test/scala/io/github/benwhitehead/finch/FinchServerTest.scala
+++ b/src/test/scala/io/github/benwhitehead/finch/FinchServerTest.scala
@@ -16,7 +16,8 @@
 package io.github.benwhitehead.finch
 
 import java.io.{BufferedReader, File, FileReader}
-import java.util.concurrent.{Future => JFuture, Callable, Executors}
+import java.net.InetSocketAddress
+import java.util.concurrent.{Callable, Executors, Future => JFuture}
 
 import com.twitter.conversions.time.intToTimeableNumber
 import com.twitter.finagle.builder.ClientBuilder
@@ -42,7 +43,7 @@ class FinchServerTest extends FreeSpec with BeforeAndAfterEach {
     lazy val pidFile = File.createTempFile("testServer", ".pid", new File(System.getProperty("java.io.tmpdir")))
     pidFile.deleteOnExit()
     override lazy val defaultHttpPort = 0
-    override lazy val config = Config(port = 0, pidPath = pidFile.getAbsolutePath)
+    override lazy val config = Config(httpInterface = Some(new InetSocketAddress("localhost", 0)), pidPath = pidFile.getAbsolutePath)
     override lazy val serverName = "test-server"
     def service = echo.toService
   }

--- a/src/test/scala/io/github/benwhitehead/finch/FlaggablesTest.scala
+++ b/src/test/scala/io/github/benwhitehead/finch/FlaggablesTest.scala
@@ -1,0 +1,53 @@
+package io.github.benwhitehead.finch
+
+import java.net.InetSocketAddress
+
+import com.twitter.app.{Flaggable, Flags}
+import com.twitter.app.Flaggable._
+import io.github.benwhitehead.finch.Flaggables._
+import org.scalatest.FreeSpec
+
+class FlaggablesTest extends FreeSpec {
+
+  "flagOfOption should" - {
+    "parse a non-empty string as a Some" in {
+      doTest("glavin", Some("glavin"))
+    }
+    "parse a non-empty string and remove leading and trailing space as a Some" in {
+      doTest("   glavin   ", Some("glavin"))
+    }
+    "parse an empty string as a None" in {
+      doTest[String]("", None)
+    }
+    "parse a string only containing spaces as a None" in {
+      doTest[String]("   ", None)
+    }
+
+    "parse a non-empty string and transform to the expected type (int)" in {
+      doTest("1", Some(1))
+    }
+
+    "parse a non-empty string and transform to the expected type (inet address, only port)" in {
+      doTest(":1234", Some(new InetSocketAddress(1234)))
+    }
+
+    "parse a non-empty string and transform to the expected type (inet address, addr and port)" in {
+      doTest("0.0.0.0:1234", Some(new InetSocketAddress("0.0.0.0", 1234)))
+    }
+
+    "parse an empty string with and expected transformation" in {
+      doTest[InetSocketAddress]("", None)
+    }
+  }
+
+  private[this] def doTest[T](in: String, expectedResult: Option[T])(implicit flaggable: Flaggable[T]): Unit = {
+    val flags = new Flags("")
+    val f = flags.apply[Option[T]]("test", None, "help")
+    f.parse(in)
+
+    val act = f()
+
+    assert(act === expectedResult)
+  }
+
+}

--- a/src/test/scala/io/github/benwhitehead/finch/TestingServer.scala
+++ b/src/test/scala/io/github/benwhitehead/finch/TestingServer.scala
@@ -1,5 +1,7 @@
 package io.github.benwhitehead.finch
 
+import java.net.InetSocketAddress
+
 import io.finch._
 
 /**
@@ -21,7 +23,7 @@ object TestingServer extends FinchServer {
   }
 
   override lazy val defaultHttpPort = 19990
-  override lazy val config = Config(port = 17070)
+  override lazy val config = Config(httpInterface = Some(new InetSocketAddress(7070)))
   override lazy val serverName = "test-server"
 
   def service = {


### PR DESCRIPTION
Update finch server such that http and https server interface configuration flags allow for specifying interface an addition to port, as well as being able to turn either server off.

Unfortunately this is a breaking change to flags and the config object, though impact should be relatively low since finch server isn't explicitly coupled to the version of finch (or even twitter server for that matter as long as the interface is stable).
